### PR TITLE
Fix: reactions in dms error for Eris 0.12.0

### DIFF
--- a/lib/ReactionHandler.js
+++ b/lib/ReactionHandler.js
@@ -9,7 +9,7 @@ class ReactionHandler extends EventEmitter {
     constructor(message, filter, permanent = false, options = {}) {
         super();
 
-        this.client     = (message.channel.guild) ? message.channel.guild.shard.client : message.channel._client;
+        this.client     = (message.channel.guild) ? message.channel.guild.shard.client : message.channel.client;
         this.filter     = filter;
         this.message    = message;
         this.options    = options;


### PR DESCRIPTION
Eris 0.12.0 and onwards broke reactions in DMs, as the client was exposed in the channel object. This PR fixes the issue. https://github.com/abalabahaha/eris/commit/ba0f2bff034859dfbf4947c28a19c6ad7f8e01bf